### PR TITLE
Add optional `ILogger` param to factory ctor

### DIFF
--- a/NHibernate.Logging.Serilog/SerilogLoggerFactory.cs
+++ b/NHibernate.Logging.Serilog/SerilogLoggerFactory.cs
@@ -8,15 +8,22 @@ namespace NHibernate.Logging.Serilog
 	/// </summary>
 	public class SerilogLoggerFactory : INHibernateLoggerFactory
 	{
+		private readonly ILogger _log;
+
+		public SerilogLoggerFactory(ILogger log = null)
+		{
+			_log = log;
+		}
+		
 		public INHibernateLogger LoggerFor(string keyName)
 		{
-			var contextLogger = Log.Logger.ForContext(Constants.SourceContextPropertyName, keyName);
+			var contextLogger = (_log ?? Log.Logger).ForContext(Constants.SourceContextPropertyName, keyName);
 			return new SerilogLogger(contextLogger);
 		}
 
 		public INHibernateLogger LoggerFor(System.Type type)
 		{
-			var contextLogger = Log.Logger.ForContext(type);
+			var contextLogger = (_log ?? Log.Logger).ForContext(type);
 			return new SerilogLogger(contextLogger);
 		}
 	}


### PR DESCRIPTION
Allow an injected `ILogger` to be used by NHibernate.